### PR TITLE
Create GameStateContext and GameStateProvider for the GameScreen and its children

### DIFF
--- a/src/factory/GameScreenCreator.tsx
+++ b/src/factory/GameScreenCreator.tsx
@@ -1,71 +1,19 @@
-import React, { useEffect, useContext, useReducer } from 'react';
-import { Animated } from 'react-native';
-import {
-  NavigationScreenProp,
-  NavigationScreenComponent,
-} from 'react-navigation';
+import React, { useEffect, useContext } from 'react';
+import { NavigationStackScreenComponent } from 'react-navigation-stack';
 
 import { GameScreen } from '../ui';
-import GameService, { createMockGameService } from '../service/GameService';
+import GameStateProvider from '../service/GameStateProvider';
 import AppContext from '../StateManager';
 
-const initialGameState: ModiGameState = {
-  round: 0,
-  dealerId: '',
-  activePlayerIdx: 0,
-  playersCards: new Map(),
-  moves: [],
-  liveCounts: [],
-  cardOrder: [1, 2, 3, 4, 5, 6],
-  playerOrder: [],
-};
+// Not yet sure if i want to make a regular http request or use socket
+// to determine if game exists
+const mockGameService = () => ({
+  isGameIdValid: (id: string) => !!id,
+});
 
-const gameStateReducer: React.Reducer<ModiGameState, GameStateChangeAction> = (
-  state,
-  action,
-) => {
-  switch (action.type) {
-    case 'set entire state':
-      return { ...action.payload };
-    case 'card order changed':
-      return { ...state, cardOrder: action.payload };
-    case 'live counts changed':
-      return { ...state, liveCounts: action.payload };
-    case 'player order changed':
-      return { ...state, playerOrder: action.payload };
-    default:
-      return state;
-  }
-};
+const GameService = mockGameService();
 
-const GameScreenCreator: React.FC<{
-  gameId: string;
-  username: string;
-  authorizedPlayerId: string;
-}> = ({ gameId, username, authorizedPlayerId }) => {
-  const [gameState, dispatchGameStateChangeAction] = useReducer(
-    gameStateReducer,
-    initialGameState,
-  );
-
-  useEffect(() => {
-    const gameConnection = createMockGameService({
-      gameId,
-      authorizedPlayerId,
-      username,
-      onGameStateChanged: dispatchGameStateChangeAction,
-    });
-    return () => gameConnection.disconnect();
-  }, []);
-
-  return <GameScreen gameState={gameState} />;
-};
-
-export default ({
-  navigation,
-}: {
-  navigation: NavigationScreenProp<{}, { id: string }>;
-}) => {
+const GameScreenCreator: NavigationStackScreenComponent = ({ navigation }) => {
   const [globalState, updateGlobalState] = useContext(AppContext);
   const { username, authorizedPlayerId } = globalState;
   const gameId = navigation.getParam('id');
@@ -83,12 +31,13 @@ export default ({
   }, [gameId]);
 
   return (
-    <GameScreenCreator
-      gameId={gameId}
+    <GameStateProvider
       username={username!}
       authorizedPlayerId={authorizedPlayerId!}
-    />
+      gameId={gameId}>
+      <GameScreen />
+    </GameStateProvider>
   );
 };
 
-// const createGameScreenWithCredentials
+export default GameScreenCreator;

--- a/src/service/GameStateProvider.tsx
+++ b/src/service/GameStateProvider.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+import io from 'socket.io-client';
+import config from 'react-native-config';
+
+type GameStateContextType = ModiGameState & { dispatch: (action: any) => void };
+const createInitialGameState = (): ModiGameState => ({
+  round: 0,
+  dealerId: '',
+  activePlayerIdx: 0,
+  playersCards: {},
+  moves: [],
+  liveCounts: [],
+  cardOrder: [],
+  playerOrder: [],
+});
+const GameStateContext = React.createContext<GameStateContextType>({
+  ...createInitialGameState(),
+  dispatch: () => {},
+});
+
+interface ModiGameStateProviderProps {
+  gameId: string;
+  authorizedPlayerId: string;
+  username: string;
+}
+const ModiGameStateProvider: React.FC<ModiGameStateProviderProps> = ({
+  children,
+  gameId,
+  username,
+  authorizedPlayerId,
+}) => {
+  const [gameState, setGameState] = React.useState<ModiGameState>(
+    createInitialGameState(),
+  );
+  const connection = React.useRef(
+    io(`${config.API_URL}/games/${gameId}`, {
+      query: { username, authorizedPlayerId },
+      autoConnect: false,
+    }),
+  ).current;
+
+  React.useEffect(() => {
+    connection.connect();
+    return () => {
+      connection.disconnect();
+    };
+  }, []);
+
+  connection.on('GAME_STATE_UPDATED', setGameState);
+
+  // Will use this to have the client send messages to the server
+  const dispatch = (action: any) => {};
+
+  return (
+    <GameStateContext.Provider value={{ ...gameState, dispatch }}>
+      {children}
+    </GameStateContext.Provider>
+  );
+};
+
+export default ModiGameStateProvider;


### PR DESCRIPTION
## Overview
The original GameService class was not the best way to get state from the server to the GameScreen, it was messy and clunky and felt overall pretty unstable.
This PR introduces a React way of achieving the same goal: using a context object and a Provider component.

## Fixes
The GameScreenCreator now discards the old GameService, and instead wraps the GameScreen in the GameStateProvider component.

## Outcomes
Now the GameScreen and all its children will have easy access to the live game state without needing to nest props or import extraneous services. It just has to call useContext and kabam.